### PR TITLE
Fix generate DBG target

### DIFF
--- a/driverkit/Makefile
+++ b/driverkit/Makefile
@@ -5,8 +5,13 @@ ifeq ($(DRIVERKIT),)
 DRIVERKIT := "/bin/driverkit"
 endif
 
+ALL_ARCHS := x86_64 aarch64
+
 # Recursive wildcard
 rwildcard=$(foreach d,$(wildcard $(1:=/*)),$(call rwildcard,$d,$2) $(filter $(subst *,%,$2),$d))
+
+# Equals function
+eq = $(and $(findstring $(1),$(2)),$(findstring $(2),$(1)))
 
 CONFIGS := $(call rwildcard,config/*,*.yaml)
 VERSIONS := $(patsubst config/%,%,$(sort $(dir $(wildcard config/*/))))
@@ -15,6 +20,7 @@ TARGET_VERSION ?= *
 TARGET_DISTRO ?= *
 TARGET_KERNEL ?= *
 TARGET_ARCH ?= *
+TARGET_ARCHS := $(if $(call eq,$(TARGET_ARCH),*),$(ALL_ARCHS),$(TARGET_ARCH))
 TARGET_HEADERS ?=
 S3_DRIVERS_BUCKET ?= "falco-distribution"
 S3_DRIVERS_KEY_PREFIX ?= "driver"
@@ -31,7 +37,7 @@ validate_new: $(patsubst config_%,validate/%,$(subst /,_,$(wildcard config/${TAR
 
 all: $(patsubst config_%,%,$(subst /,_,$(CONFIGS)))
 
-specific_target: specific_target_old specific_target_new
+specific_target: specific_target_new
 # old fmt had x86_64 only in root folder. Note: this breaks filtering for TARGET_ARCH
 # because specific_target_old will always build any old config.
 # Not a big deal because we were not going to filter for TARGET_ARCH in any case.
@@ -45,13 +51,16 @@ publish: $(addprefix publish_,$(VERSIONS))
 publish_s3: $(addprefix publish_s3_,$(VERSIONS))
 
 generate:
-	$(foreach VERSION,$(VERSIONS),\
-		utils/generate -a $(TARGET_ARCH) -k ${TARGET_KERNEL} -d ${TARGET_DISTRO} -h ${TARGET_HEADERS} -v ${VERSION}; \
+	$(foreach ARCH,$(TARGET_ARCHS),\
+		$(foreach VERSION,$(VERSIONS),\
+			utils/generate -a '$(ARCH)' -k '${TARGET_KERNEL}' -d '${TARGET_DISTRO}' -h '${TARGET_HEADERS}' -v '${VERSION}'; \
+		)\
 	)
 
 generate/auto:
-	utils/scrape_and_generate "x86_64"
-	utils/scrape_and_generate "aarch64"
+	$(foreach ARCH,$(TARGET_ARCHS),\
+		utils/scrape_and_generate $(ARCH); \
+	)
 
 cleanup:
 	utils/cleanup -p ${BINTRAY_SECRET} $(addprefix -v ,$(VERSIONS))

--- a/driverkit/Makefile
+++ b/driverkit/Makefile
@@ -37,7 +37,7 @@ validate_new: $(patsubst config_%,validate/%,$(subst /,_,$(wildcard config/${TAR
 
 all: $(patsubst config_%,%,$(subst /,_,$(CONFIGS)))
 
-specific_target: specific_target_new
+specific_target: specific_target_old specific_target_new
 # old fmt had x86_64 only in root folder. Note: this breaks filtering for TARGET_ARCH
 # because specific_target_old will always build any old config.
 # Not a big deal because we were not going to filter for TARGET_ARCH in any case.


### PR DESCRIPTION
Since `utils/generate` does not accept '*' as architecture name it fails to generate the configuration with proper architecture field value.

E.g.:
```
$ make -e TARGET_VERSION=1.0.0 -e TARGET_DISTRO=amazonlinux2 -e TARGET_KERNEL=4.14.101 generate                                  (kind-kind/default)[15:07:10]
utils/generate -a * -k 4.14.101 -d amazonlinux2 -h  -v 1.0.0;   utils/generate -a * -k 4.14.101 -d amazonlinux2 -h  -v 17f5df52a7d9ed6bb12d3b1768460def8439936d;   utils/generate -a * -k 4.14.101 -d amazonlinux2 -h  -v 319368f1ad778691164d33d59945e00c5752cd27;   utils/generate -a * -k 4.14.101 -d amazonlinux2 -h  -v 39ae7d40496793cf3d3e7890c9bbdc202263836b;   utils/generate -a * -k 4.14.101 -d amazonlinux2 -h  -v 3aa7a83bf7b9e6229a3824e3fd1f4452d1e95cb4;   utils/generate -a * -k 4.14.101 -d amazonlinux2 -h  -v 5c0b863ddade7a45568c0ac97d037422c9efb750;   utils/generate -a * -k 4.14.101 -d amazonlinux2 -h  -v b7eb0dd65226a8dc254d228c8d950d07bf3521d2;
---
<omitted>
---
kernelversion: 1
kernelrelease: 4.14.101
target: amazonlinux2
architecture: unknown architecture
output:
  module: output/1.0.0/config/falco_amazonlinux2_4.14.101_1.ko
  probe: output/1.0.0/config/falco_amazonlinux2_4.14.101_1.o
...
<omitted>
```
> This is not so elegant and it will be good to leverage Make wildcard and generate "generate" target dependencies dynamically.

Signed-off-by: Massimiliano Giovagnoli <me@maxgio.it>